### PR TITLE
Anonymize user names by encrypting with md5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ Matomo tracking for TDP applications based on provenance graph commands.
 Configuration
 ------------
 
-The tracking starts when a URL to a Matomo backend is set in the `config.js`.
-The site ID corresponds with the Matomo site.
+* The tracking starts when a URL to a Matomo backend is set in the `config.js`.
+* The site ID corresponds with the Matomo site.
+* Enable the [md5](https://en.wikipedia.org/wiki/MD5) encryption of user names to prevent plaintext logging (e.g., when using Matomo with LDAP login)
 
 ```js
 {
   "matomo": {
     "url": "https://matomo.my-example-domain.com/", // matomo url with a trailing slash
-    "site": "1"
+    "site": "1",
+    "encryptUserName": false
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "ts-loader": "4.0.1"
   },
   "dependencies": {
+    "crypto-js": "^3.1.9-1",
     "tdp_core": "github:datavisyn/tdp_core#develop"
   }
 }

--- a/tdp_matomo/config.json
+++ b/tdp_matomo/config.json
@@ -1,6 +1,7 @@
 {
   "matomo": {
     "url": "", // matomo url with a trailing slash
-    "site": "1"
+    "site": "1",
+    "encryptUserName": false
   }
 }


### PR DESCRIPTION
Fix #4

* Add the config option to encrypt the user name with md5

**Disabled encryption** (`encryptUserName: false`)

![grafik](https://user-images.githubusercontent.com/5851088/64948802-24684880-d878-11e9-866d-20eb59d9ff0d.png)

**Enabled encryption** (`encryptUserName: true`)

![grafik](https://user-images.githubusercontent.com/5851088/64948909-5da0b880-d878-11e9-823d-ad10bacffa2b.png)

**Check MD5**

https://duckduckgo.com/?q=md5+sleepy_joliot&ia=answer

```
md5('sleepy_joliot') = "c886fd6fd5db111c018ec2a90843f515"
```